### PR TITLE
REMOVE tab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome To My Portfolio WebPage
 
 
-Click here to go to WebSite [Open Portfolio](https://nicolaijgangdal.github.io/WebPortfolio){:target="_blank"}
+Click here to go to WebSite [Open Portfolio](https://nicolaijgangdal.github.io/WebPortfolio).
 
 
 


### PR DESCRIPTION
GitHub does not support the "target" attribute in the README.md. So the user just has to CTRL + click the link