### PR TITLE
ADD Media Query

### DIFF
--- a/src/styles/Experience.css
+++ b/src/styles/Experience.css
@@ -1,3 +1,5 @@
-.placing {
-    margin-left: -4%;
+@media (min-width: 1170px) {
+  .placing {
+      margin-left: -4%;
   }
+}


### PR DESCRIPTION
Added media query to the Experience.css. This removes the centering of the experience timeline when the screen size is smaller than 1170 pixels.